### PR TITLE
add impressum contains de and en because of .dev url

### DIFF
--- a/impressum-new-work-skills-dev.md
+++ b/impressum-new-work-skills-dev.md
@@ -1,0 +1,76 @@
+# Impressum — new-work-skills.dev
+
+---
+
+## DE — Angaben gemäss UWG Art. 3 lit. s und nDSG
+
+### Betreiber dieser Website
+
+Robert Halter
+Neuseeland 30B
+9404 Rorschacherberg, SG
+Schweiz
+
+### Kontakt
+
+E-Mail: [new-work-skills@halter.in](mailto:new-work-skills@halter.in)
+
+### Zweck der Website
+
+Informationswebsite zur new-work-skills-Methodik — Umwandlung von Howtos in
+wiederverwendbare, teilbare Skills.
+
+### Verantwortlicher im Sinne des nDSG
+
+Robert Halter, Adresse wie oben.
+Kontakt für Datenschutzanfragen: [new-work-skills@halter.in](mailto:new-work-skills@halter.in)
+
+### Haftungsausschluss für Links
+
+Diese Website enthält Links zu externen Websites Dritter, insbesondere zu
+agentskills.io, github.com und claude.ai. Auf deren Inhalte haben wir keinen
+Einfluss. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter
+oder Betreiber verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der
+Verlinkung auf mögliche Rechtsverstösse geprüft. Rechtswidrige Inhalte waren
+zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche
+Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer
+Rechtsverletzung nicht zumutbar.
+
+*Stand: März 2026*
+
+---
+
+## EN — Legal Notice pursuant to Swiss UWG Art. 3 lit. s and nDSG
+
+### Website Operator
+
+Robert Halter
+Neuseeland 30B
+9404 Rorschacherberg, SG
+Switzerland
+
+### Contact
+
+Email: [new-work-skills@halter.in](mailto:new-work-skills@halter.in)
+
+### Purpose of this website
+
+Informational website about the new-work-skills methodology — transforming
+howtos into reusable, shareable Skills.
+
+### Data controller pursuant to nDSG
+
+Robert Halter, address as above.
+Contact for data protection inquiries: [new-work-skills@halter.in](mailto:new-work-skills@halter.in)
+
+### Disclaimer for external links
+
+This website contains links to external third-party websites, including
+agentskills.io, github.com, and claude.ai. We have no influence over their
+content. The respective provider or operator of the linked pages is always
+responsible for their content. The linked pages were checked for possible legal
+violations at the time of linking. No illegal content was apparent at the time
+of linking. However, permanent monitoring of the linked pages is not reasonable
+without concrete indications of a legal violation.
+
+*Last updated: March 2026*


### PR DESCRIPTION
add impressum generated by using my own skill create-impressum-ch-en

at
https://github.com/roebi/agent-skills/blob/main/skills/create-impressum-ch-en/SKILL.md